### PR TITLE
fix(curriculum): add missing default image for fortune-teller-app

### DIFF
--- a/build/curriculum/typescript/tarot-app/default.svg
+++ b/build/curriculum/typescript/tarot-app/default.svg
@@ -1,0 +1,9 @@
+<svg width="120" height="200" xmlns="http://www.w3.org/2000/svg">
+    <rect width="120" height="200" rx="12" fill="#eee"
+        stroke="#bbb" stroke-width="4" />
+    <text x="50%" y="50%" dominant-baseline="middle"
+        text-anchor="middle" fill="#888" font-size="20"
+        font-family="Arial">
+        No Image
+    </text>
+</svg>


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ X ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ X ] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Ref [#67967](https://github.com/freeCodeCamp/freeCodeCamp/issues/67967)

<!-- Feel free to add any additional description of changes below this line -->

Adds default.svg to `curriculum/typescript/tarot-app` so that it can be used in Fortune Teller App Workshop